### PR TITLE
Add math include.

### DIFF
--- a/SHT31.cpp
+++ b/SHT31.cpp
@@ -1,4 +1,5 @@
 #include "SHT31.h"
+#include <math.h>
 
 SHT31::SHT31() {
 }


### PR DESCRIPTION
'math.h'インクルードを追加
いくつかのボードプラットフォームで、`math.h`がないためNANが宣言されていないエラーが発生していました。

**エラーログ**
```
Grove_SHT31_Temp_Humi_Sensor/SHT31.cpp:16:30: error: 'NAN' was not declared in this scope
   if (! getTempHum()) return NAN;
                              ^~~
Grove_SHT31_Temp_Humi_Sensor/SHT31.cpp:22:30: error: 'NAN' was not declared in this scope
   if (! getTempHum()) return NAN;
                              ^~~
```